### PR TITLE
Added: NSAppTransportSecurity key to Info.plist for iOS 9 and later

### DIFF
--- a/FreesoundSampleApp/FreesoundSampleApp-Info.plist
+++ b/FreesoundSampleApp/FreesoundSampleApp-Info.plist
@@ -36,5 +36,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSAppTransportSecurity </key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
Otherwise, you'll get errors like this: 
Application Transport Security has blocked a cleartext HTTP (http://) resource load since it is insecure. Temporary exceptions can be configured via your app's Info.plist file. http://www.freesound.org/apiv2/search/text/?&fields=id,name,username,description,previews,images&query=...

Reference:
https://developer.apple.com/library/prerelease/ios/technotes/App-Transpo
rt-Security-Technote/index.html
https://forums.developer.apple.com/thread/3544
